### PR TITLE
auto tag in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,14 @@ jobs:
         id: check_tag
         uses: anothrNick/check-tag@v1.1.1
         with:
-          tag_name: 'v${{ steps.get_version.outputs.version }}'
-        
+          tag_name: "v${{ steps.get_version.outputs.version }}"
+
       - name: Create Tag
         id: create_tag
         uses: anothrNick/github-tag-action@v1.33.0
         with:
-          tag_name: 'v${{ steps.get_version.outputs.version }}'
-          message: 'v${{ steps.get_version.outputs.version }} released'
+          tag_name: "v${{ steps.get_version.outputs.version }}"
+          message: "v${{ steps.get_version.outputs.version }} released"
 
       - name: Push Tag
         uses: anothrNick/github-tag-action@v1.33.0
@@ -100,6 +100,7 @@ jobs:
           push: true
 
   publish:
+    name: Publish Extension
     runs-on: ubuntu-latest
     needs: tag
     if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,43 @@ jobs:
           name: ${{ env.target }}
           path: "*.vsix"
 
-  publish:
+  tag:
+    name: Create Version Tag
     runs-on: ubuntu-latest
     needs: build
-    if: success() && startsWith( github.ref, 'refs/tags/')
+    # Only tag if all builds are successful and the branch is main
+    if: success() && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get Version
+        id: get_version
+        run: echo ::set-output name=version::$(node -p "require('./package.json').version")
+
+      - name: Check Tag
+        id: check_tag
+        uses: anothrNick/check-tag@v1.1.1
+        with:
+          tag_name: 'v${{ steps.get_version.outputs.version }}'
+        
+      - name: Create Tag
+        id: create_tag
+        uses: anothrNick/github-tag-action@v1.33.0
+        with:
+          tag_name: 'v${{ steps.get_version.outputs.version }}'
+          message: 'v${{ steps.get_version.outputs.version }} released'
+
+      - name: Push Tag
+        uses: anothrNick/github-tag-action@v1.33.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          push: true
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: tag
+    if: success()
     steps:
       - uses: actions/download-artifact@v2
       - run: npx vsce publish --packagePath $(find . -iname *.vsix)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

- New Feature: Added a job to create and push a version tag only when the branch is main, and modified the existing publish job to depend on the new tag job.

> "Tags are now created with ease,
> Only for main, if you please.
> Consistency is key,
> With this PR, we can all agree."
<!-- end of auto-generated comment: release notes by openai -->